### PR TITLE
Updating count of Google Fonts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ There are several ways to try Samsa:
 ## Try some fonts in Samsa
 
 There are many open source variable fonts to try in Samsa, including:
-* [Google Fonts](https://fonts.google.com/?vfonly) (34 fonts, 1 axis)
+* [Google Fonts](https://fonts.google.com/?vfonly) (38 fonts, 1 axis)
 * [IBM Plex Sans Var](https://github.com/IBM/plex/tree/master/IBM-Plex-Sans-Variable) (2 fonts, 2 axis)
 * Adobe [Source Serif, Source Sans, Source Code](https://github.com/adobe-fonts) (6 fonts, 1 axis)
 * [Amstelvar](https://github.com/TypeNetwork/Amstelvar/) (2 fonts, 12 axes)


### PR DESCRIPTION
As of today, 38 VF listed on Google Fonts.
Its also likely that some of these fonts have more than one axis when downloaded, but only a single axis is being exposed on API served fonts.