### PR TITLE
Allow panel area to resize.

### DIFF
--- a/src/samsa-gui.css
+++ b/src/samsa-gui.css
@@ -136,7 +136,7 @@ button.close {
 	width: 100vw;
 	height: 100vh;
 	display: grid;
-	grid-template-columns: 360px 1fr;
+	grid-template-columns: 0fr 1fr;
 	grid-template-rows: 80px 1fr;
 	background-color: beige;
 	/* on font load becomes transparent */
@@ -203,7 +203,11 @@ button.close {
 .panel-container {
 	position: relative;
 	background-color: beige;
+	overflow-x: auto;
 	overflow-y: scroll;
+	resize: horizontal;
+	min-width: 360px;
+	max-width: 50vw;
 }
 
 


### PR DESCRIPTION
When there are many axes the "Delta Sets" view can get quite wide, and
other panels can also get a bit crowded. Allow the user to resize the
panel area.

Note that this is more a request for this feature with a simple possible implementation.  This change was made in a local fork to make it a bit easier to look at fonts which make the panels wide.