### PR TITLE
Allow "Delta sets" panel content to scroll in x.

### DIFF
--- a/src/samsa-gui.css
+++ b/src/samsa-gui.css
@@ -642,7 +642,7 @@ h4 {
 .tvt-item {
 	display: grid;
 	grid-template-columns: 25px 15px 45px 45px 45px auto;
-	grid-template-rows: 2em;
+	grid-template-rows: auto;
 	font-size: 75%;
 }
 

--- a/src/samsa-gui.html
+++ b/src/samsa-gui.html
@@ -1458,6 +1458,7 @@ function vfLoaded (font) {
 	//panel.innerText = "";
 
 	panel.innerHTML = "This font does not contain delta sets.";
+	panel.style.overflowX = "scroll";
 
 
 
@@ -2497,7 +2498,7 @@ function updateTvts (glyph, iglyph) {
 		// add main row: <li>
 		li = EL("li");
 		li.classList.add("tvt-item");
-		let row = `<div class="index" style="height: 2em;background-color: ${ui.tuple.colors[t % ui.tuple.colors.length]}">${t}</div><div class="toggle bold icon">&#xf04b;</div><div class="points">${numDeltas}</div><div class="scalar" style="text-align: center;">${Math.round(sValue *1000)/1000}</div><div class="order">${tvtOrder}</div><div class="axes"></div>`;
+		let row = `<div class="index" style="height: 100%;background-color: ${ui.tuple.colors[t % ui.tuple.colors.length]}">${t}</div><div class="toggle bold icon">&#xf04b;</div><div class="points">${numDeltas}</div><div class="scalar" style="text-align: center;">${Math.round(sValue *1000)/1000}</div><div class="order">${tvtOrder}</div><div class="axes"></div>`;
 		li.innerHTML = row;
 		panel.append(li);
 


### PR DESCRIPTION
In Decovar and other fonts with many axes the "Delta sets" panel
displays a large number of ramps which are not easy to see. Allow the
contents of the panel to scroll. In the future it may be nice to allow
scrolling of the axes only.

The changes to the grid rows prevents the appearance of a vertical
scrollbar when the div containing the svg ramps is larger than 2em,
causing the last delta set representation to overflow the last grid row.