### PR TITLE
dynamic svg size for SamsaGlyph.prototype.svg()

### DIFF
--- a/src/samsa-core.js
+++ b/src/samsa-core.js
@@ -1138,7 +1138,7 @@ SamsaGlyph.prototype.svg = function (style={}) {
 	          + (style.fill ? ` fill="${style.fill}"` : "")
 	          + (style.stroke ? ` stroke="${style.stroke}"` : "")
 	          + (style.strokeWidth ? ` stroke-width="${style.strokeWidth}"` : "");
-	return `<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="1000" height="1000">
+	return `<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="${this.font.unitsPerEm}" height="${this.font.unitsPerEm}">
 	<g${style.transform ? ` transform="${style.transform}"` : ""}>
 		<path d="${this.svgPath()}"${extra}></path>
 	</g>


### PR DESCRIPTION
update SamsaGlyph.prototype.svg function so the exported SVG's width and height is set dynamically with font.unitsPerEm
this helps with fonts with non-standard canvas size.